### PR TITLE
fixes login field on iOS

### DIFF
--- a/src/lib/items/Input.svelte
+++ b/src/lib/items/Input.svelte
@@ -14,9 +14,12 @@
 </script>
 
 <div class="input">
+    <form>
     {#if password}
         <input
             type="password"
+            autocomplete="new-password"
+            id="pwd"
             bind:this={element}
             {placeholder}
             on:change
@@ -33,6 +36,7 @@
             bind:value={value}
         />
     {/if}
+    </form>
     <button on:click={clear}>x</button>
 </div>
 


### PR DESCRIPTION
When loading the page for the first time with a password iOS could not focus on the input field and the keyboard would not popup. 

After adding the <form></form> tags tot he html and adding the id and autocomplete properties to the input field it works as expected.